### PR TITLE
Removing one of the pairing rules assertions: Generating FHIR-HF with an undefined onsetDate, when HF was reported on a follow-up assessment, and the assessment date is not available. Address issue #19

### DIFF
--- a/fhirvalidation/sampleinputs/input-p11111.json
+++ b/fhirvalidation/sampleinputs/input-p11111.json
@@ -1,0 +1,71 @@
+{
+    "project_pseudo_id": {"1a":"11111"},
+    "variant_id": {},
+
+    "date": {"1a":"1992-5","1b":"1995-5","1c":"1997-5","2a":"2001-5","2b":"2002-5","3a":"2003-5","3b":"2005-5"},    
+    "age": {"1a":"22"},
+    "gender": {"1a":"MALE"},
+    "zip_code": {"1a":"11111"},
+    "date_of_death": {"global":"2010-2"},
+    "date_of_inclusion": {"global":"1991-2"},
+
+    "albumin_result_all_m_1" :{ "1a": "51"},
+    
+    "creatinine_result_all_m_1":{ "1a": "79.2", "2a":"106.1"},
+    "hemoglobin_result_all_m_1" :{ "1a": "11.1", "2a":"12"},
+    
+    "ethnicity_category_adu_q_1":{"1b":"3"},        
+    "hba1cconc_result_all_m_1":{ "1a": "43", "2a":"44"},
+
+    "hypertension_startage_adu_q_1":{"1a":"","3a":"23","3b":"23"},
+    "hypertension_presence_adu_q_1":{"1a":"2","3a":"1","3b":"1"},
+
+    "stroke_startage_adu_q_1":{ "1a": "12" },
+    "stroke_presence_adu_q_1": { "1a": "1" },
+    "stroke_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+    "diabetes_presence_adu_q_1":    {"1a":"1"},
+    "diabetes_startage_adu_q_1":    {"1a":"28"},
+    "diabetes_followup_adu_q_1":    {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "diabetes_type_adu_q_1":        {"1a":"2"},
+    "diabetes_type_adu_q_1_a":      {"1a":""},
+    "t1d_followup_adu_q_1":         {"2a":"2","3a":"2","3b":"2"},
+    "t2d_followup_adu_q_1":         {"2a":"2","3a":"2","3b":"2"},
+
+    "bp_entrytype_all_m_1":         {"1a":"2","2a":"2"},
+    "bp_bandsize_all_m_1":          {"1a":"1","2a":"1","3a":"1"},
+    "bp_arm_all_m_1":                           {"3a":"2"},
+    "bpavg_systolic_all_m_1":       {"1a":"130","2a":"130"},
+    "bpavg_diastolic_all_m_1":      {"1a":"140","2a":"140"},
+    "bpavg_arterial_all_m_1":       {"1a":"113","2a":"113"},
+
+    "hdlchol_result_all_m_1":       {"1a":"0.31","2a":"0.22"},
+    "ldlchol_result_all_m_1":       {"1a":"0.41","2a":"0.42"},
+    "cholesterol_result_all_m_1":   {"1a":"0.51","2a":"0.52"},
+    
+    "heartattack_startage_adu_q_1": {"1a":"33"},
+    "angioplasty_bypass_adu_q_1_a":  {"1a":"1","3a":"1","3b":"1"},
+    "heartattack_presence_adu_q_1": {"1a":"1"},
+    "heartattack_followup_adu_q_1":     {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "angioplasty_bypass_adu_q_1":   {"1a":"1","3a":"1","3b":"1"},
+
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "2" },
+    "heartfailure_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+    "carotid_stenosis_adu_q_1":     {"1a":"1"},
+    "claudication_followup_adu_q_1":            {"2a":"2","3a":"2","3b":"2"},
+    "cvd_followup_adu_q_1":             {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+
+    "current_smoker_adu_c_2": { "1a": "0", "1b": "0", "1c": "0", "2a": "0", "2b": "0", "3a": "0" },
+    "smoking_startage_adu_c_2": { "1a": "5", "1b": "5", "1c": "5", "2a": "5", "2b": "5", "3a": "5" },
+    "ex_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1" },
+    "smoking_endage_adu_c_2": { "1a": "8", "1b": "8", "1c": "8", "2a": "8", "2b": "8", "3a": "8"},
+    "ever_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1"},
+    "total_frequency_adu_c_1": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""},
+    "packyears_cumulative_adu_c_2": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""}
+
+
+
+}
+

--- a/fhirvalidation/sampleinputs/input-p675432-hf-followup-missing-date.json
+++ b/fhirvalidation/sampleinputs/input-p675432-hf-followup-missing-date.json
@@ -1,0 +1,71 @@
+{
+    "project_pseudo_id": {"1a":"675432"},
+    "variant_id": {},
+
+    "date": {"1a":"1992-5","1b":"1995-5","1c":"1997-5","2a":"2001-5","2b":"2002-5","3a":"","3b":"2005-5"},
+    
+    "age": {"1a":"22"},
+    "gender": {"1a":"MALE"},
+    "zip_code": {"1a":"11111"},
+    "date_of_death": {"global":"2010-2"},
+    "date_of_inclusion": {"global":"1991-2"},
+    
+    "albumin_result_all_m_1" :{ "1a": "51"},
+    "creatinine_result_all_m_1":{ "1a": "79.2", "2a":"106.1"},
+    "ethnicity_category_adu_q_1":{"1b":"3"},
+    "hemoglobin_result_all_m_1" :{ "1a": "11.1", "2a":"12"},
+    "hba1cconc_result_all_m_1":{ "1a": "43", "2a":"44"},
+
+    "hypertension_startage_adu_q_1":{"1a":"","3a":"23","3b":"23"},
+    "hypertension_presence_adu_q_1":{"1a":"2","3a":"1","3b":"1"},
+
+    "stroke_startage_adu_q_1":{ "1a": "12" },
+    "stroke_presence_adu_q_1": { "1a": "1" },
+    "stroke_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+
+    "diabetes_presence_adu_q_1":    {"1a":"1"},
+    "diabetes_startage_adu_q_1":    {"1a":"28"},
+    "diabetes_followup_adu_q_1":        {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "diabetes_type_adu_q_1":        {"1a":"2"},
+    "diabetes_type_adu_q_1_a":      {"1a":""},
+    "t1d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+    "t2d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+
+    "bp_entrytype_all_m_1":         {"1a":"2","2a":"2"},
+    "bp_bandsize_all_m_1":          {"1a":"1","2a":"1","3a":"1"},
+    "bp_arm_all_m_1":                           {"3a":"2"},
+    "bpavg_systolic_all_m_1":       {"1a":"130","2a":"130"},
+    "bpavg_diastolic_all_m_1":      {"1a":"140","2a":"140"},
+    "bpavg_arterial_all_m_1":       {"1a":"113","2a":"113"},
+
+    "hdlchol_result_all_m_1":       {"1a":"0.31","2a":"0.22"},
+    "ldlchol_result_all_m_1":       {"1a":"0.41","2a":"0.42"},
+    "cholesterol_result_all_m_1":   {"1a":"0.51","2a":"0.52"},
+    
+    "heartattack_startage_adu_q_1": {"1a":"33"},
+    "angioplasty_bypass_adu_q_1_a":  {"1a":"1","3a":"1","3b":"1"},
+    "heartattack_presence_adu_q_1": {"1a":"1"},
+    "heartattack_followup_adu_q_1":     {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "angioplasty_bypass_adu_q_1":   {"1a":"1","3a":"1","3b":"1"},
+
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "2" },
+    "heartfailure_followup_adu_q_1":{"2a":"2","3a":"1","3b":"2"},
+
+    "carotid_stenosis_adu_q_1":     {"1a":"1"},
+    "claudication_followup_adu_q_1":            {"2a":"2","3a":"2","3b":"2"},
+    "cvd_followup_adu_q_1":             {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+
+    "current_smoker_adu_c_2": { "1a": "0", "1b": "0", "1c": "0", "2a": "0", "2b": "0", "3a": "0" },
+    "smoking_startage_adu_c_2": { "1a": "5", "1b": "5", "1c": "5", "2a": "5", "2b": "5", "3a": "5" },
+    "ex_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1" },
+    "smoking_endage_adu_c_2": { "1a": "8", "1b": "8", "1c": "8", "2a": "8", "2b": "8", "3a": "8"},
+    "ever_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1"},
+    "total_frequency_adu_c_1": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""},
+    "packyears_cumulative_adu_c_2": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""}
+
+
+
+}
+

--- a/fhirvalidation/sampleinputs/input-p8737232-nocvd.json
+++ b/fhirvalidation/sampleinputs/input-p8737232-nocvd.json
@@ -1,0 +1,73 @@
+{
+    "project_pseudo_id": {"1a":"8737232"},
+    "variant_id": {},
+
+    "date": {"1a":"1990-1","1b":"1995-5","1c":"1997-5","2a":"2000-1","2b":"2001-1","3a":"2003-5","3b":"2005-5"},
+    "age": { "1a": "40" },  
+    "gender": {"1a":"FEMALE"},
+    "date_of_death": {"global":""},
+    "date_of_inclusion": {"global":"1991-2"},
+
+    "albumin_result_all_m_1" :{ "1a": "34"},
+    "creatinine_result_all_m_1":{ "1a": "79.2", "2a":"106.1"},
+    "ethnicity_category_adu_q_1":{"1b":"1"},
+    "hemoglobin_result_all_m_1" :{ "1a": "6", "2a":"12"},  
+    "hba1cconc_result_all_m_1":{ "1a": "43", "2a":"44"},  
+
+    "zip_code": {"1a":"11111"},
+
+    "hypertension_startage_adu_q_1":{"1a":"","3a":"23","3b":"23"},
+    "hypertension_presence_adu_q_1":{"1a":"2","3a":"1","3b":"1"},
+
+    "stroke_startage_adu_q_1":{ "1a": "" },
+    "stroke_presence_adu_q_1": { "1a": "2" },
+    "stroke_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+    "heartattack_startage_adu_q_1": {"1a":""},
+    "heartattack_presence_adu_q_1": {"1a":"2"},
+    "heartattack_followup_adu_q_1":     {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "2" },
+    "heartfailure_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+
+
+    "diabetes_presence_adu_q_1":    {"1a":"1"},
+    "diabetes_startage_adu_q_1":    {"1a":"28"},
+    "diabetes_followup_adu_q_1":        {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "diabetes_type_adu_q_1":        {"1a":"2"},
+    "diabetes_type_adu_q_1_a":      {"1a":""},
+    "t1d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+    "t2d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+
+    "bp_entrytype_all_m_1":         {"1a":"2","2a":"2"},
+    "bp_bandsize_all_m_1":          {"1a":"1","2a":"1","3a":"1"},
+    "bp_arm_all_m_1":                           {"3a":"2"},
+    "bpavg_systolic_all_m_1":       {"1a":"","2a":""},
+    "bpavg_diastolic_all_m_1":      {"1a":"","2a":""},
+    "bpavg_arterial_all_m_1":       {"1a":"","2a":"113"},
+
+    "hdlchol_result_all_m_1":       {"1a":"","2a":"0.32"},
+    "ldlchol_result_all_m_1":       {"1a":"0.41","2a":""},
+    "cholesterol_result_all_m_1":   {"1a":"0.51","2a":"0.52"},
+    
+    
+    
+    "angioplasty_bypass_adu_q_1_a":  {"1a":"1","3a":"1","3b":"1"},
+    
+    "angioplasty_bypass_adu_q_1":   {"1a":"1","3a":"1","3b":"1"},
+    "carotid_stenosis_adu_q_1":     {"1a":"1"},
+    "claudication_followup_adu_q_1":            {"2a":"2","3a":"2","3b":"2"},
+    "cvd_followup_adu_q_1":             {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+
+    "current_smoker_adu_c_2": { "1a": "0", "1b": "0", "1c": "0", "2a": "0", "2b": "0", "3a": "0" },
+    "smoking_startage_adu_c_2": { "1a": "5", "1b": "5", "1c": "5", "2a": "5", "2b": "5", "3a": "5" },
+    "ex_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1" },
+    "smoking_endage_adu_c_2": { "1a": "8", "1b": "8", "1c": "8", "2a": "8", "2b": "8", "3a": "8"},
+    "ever_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1"},
+    "total_frequency_adu_c_1": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""},
+    "packyears_cumulative_adu_c_2": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""}
+
+}
+

--- a/fhirvalidation/sampleinputs/input-p98765-unreported-hf-startage.json
+++ b/fhirvalidation/sampleinputs/input-p98765-unreported-hf-startage.json
@@ -1,0 +1,71 @@
+{
+    "project_pseudo_id": {"1a":"98765"},
+    "variant_id": {},
+
+    "date": {"1a":"1992-5","1b":"1995-5","1c":"1997-5","2a":"2001-5","2b":"2002-5","3a":"2003-5","3b":"2005-5"},
+    
+    "age": {"1a":"22"},
+    "gender": {"1a":"MALE"},
+    "zip_code": {"1a":"11111"},
+    "date_of_death": {"global":"2010-2"},
+    "date_of_inclusion": {"global":"1991-2"},
+    
+    "albumin_result_all_m_1" :{ "1a": "51"},
+    "creatinine_result_all_m_1":{ "1a": "79.2", "2a":"106.1"},
+    "ethnicity_category_adu_q_1":{"1b":"3"},
+    "hemoglobin_result_all_m_1" :{ "1a": "11.1", "2a":"12"},
+    "hba1cconc_result_all_m_1":{ "1a": "43", "2a":"44"},
+
+    "hypertension_startage_adu_q_1":{"1a":"","3a":"23","3b":"23"},
+    "hypertension_presence_adu_q_1":{"1a":"2","3a":"1","3b":"1"},
+
+    "stroke_startage_adu_q_1":{ "1a": "12" },
+    "stroke_presence_adu_q_1": { "1a": "1" },
+    "stroke_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+
+    "diabetes_presence_adu_q_1":    {"1a":"1"},
+    "diabetes_startage_adu_q_1":    {"1a":"28"},
+    "diabetes_followup_adu_q_1":        {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "diabetes_type_adu_q_1":        {"1a":"2"},
+    "diabetes_type_adu_q_1_a":      {"1a":""},
+    "t1d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+    "t2d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+
+    "bp_entrytype_all_m_1":         {"1a":"2","2a":"2"},
+    "bp_bandsize_all_m_1":          {"1a":"1","2a":"1","3a":"1"},
+    "bp_arm_all_m_1":                           {"3a":"2"},
+    "bpavg_systolic_all_m_1":       {"1a":"130","2a":"130"},
+    "bpavg_diastolic_all_m_1":      {"1a":"140","2a":"140"},
+    "bpavg_arterial_all_m_1":       {"1a":"113","2a":"113"},
+
+    "hdlchol_result_all_m_1":       {"1a":"0.31","2a":"0.22"},
+    "ldlchol_result_all_m_1":       {"1a":"0.41","2a":"0.42"},
+    "cholesterol_result_all_m_1":   {"1a":"0.51","2a":"0.52"},
+    
+    "heartattack_startage_adu_q_1": {"1a":"33"},
+    "angioplasty_bypass_adu_q_1_a":  {"1a":"1","3a":"1","3b":"1"},
+    "heartattack_presence_adu_q_1": {"1a":"1"},
+    "heartattack_followup_adu_q_1":     {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "angioplasty_bypass_adu_q_1":   {"1a":"1","3a":"1","3b":"1"},
+
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "1" },
+    "heartfailure_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
+
+    "carotid_stenosis_adu_q_1":     {"1a":"1"},
+    "claudication_followup_adu_q_1":            {"2a":"2","3a":"2","3b":"2"},
+    "cvd_followup_adu_q_1":             {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+
+    "current_smoker_adu_c_2": { "1a": "0", "1b": "0", "1c": "0", "2a": "0", "2b": "0", "3a": "0" },
+    "smoking_startage_adu_c_2": { "1a": "5", "1b": "5", "1c": "5", "2a": "5", "2b": "5", "3a": "5" },
+    "ex_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1" },
+    "smoking_endage_adu_c_2": { "1a": "8", "1b": "8", "1c": "8", "2a": "8", "2b": "8", "3a": "8"},
+    "ever_smoker_adu_c_2": { "1a": "1", "1b": "1", "1c": "1", "2a": "1", "2b": "1", "3a": "1"},
+    "total_frequency_adu_c_1": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""},
+    "packyears_cumulative_adu_c_2": { "1a": "", "1b": "", "1c": "", "2a": "", "2b": "", "3a": ""}
+
+
+
+}
+

--- a/src/__tests__/heartfailure.test.ts
+++ b/src/__tests__/heartfailure.test.ts
@@ -3,6 +3,7 @@ import { heartFailure } from '../lifelines/HeartFailure';
 import { MappingTarget, processInput } from '../mapper'
 import {getSNOMEDCode} from '../codes/codesCollection'
 
+
 test('heartfailure, when reported positive in 1A', () => {
 
   const input = {
@@ -24,6 +25,27 @@ test('heartfailure, when reported positive in 1A', () => {
 });
 
 
+test('heartfailure, when reported positive in 1A, but no start_age was reported', () => {
+
+  const input = {
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "1" },
+    "heartfailure_followup_adu_q_1":{"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "date": {"1a":"1992-5","1b":"1995-5","1c":"1997-5","2a":"2001-5","2b":"2002-5","3a":"2003-5","3b":"2005-5"},
+    "age": { "1a": "22" }
+  }
+
+  InputSingleton.getInstance().setInput(input);
+  
+
+  expect(heartFailure.clinicalStatus()?.display).toBe("Active");
+  expect(heartFailure.isPresent()).toBe(true);
+  expect(heartFailure.code().display).toBe("Heart failure (disorder)");
+  expect(heartFailure.onsetDateTime()).toBe(undefined);
+  
+});
+
+
 test('heart failure, when reported in 2A', () => {
 
   const input = {
@@ -41,6 +63,26 @@ test('heart failure, when reported in 2A', () => {
   expect(heartFailure.onsetDateTime()).toBe("1999-05");
   
 });
+
+
+test('heart failure, when reported in 2A, but there is no assessment date available for 2A', () => {
+
+  const input = {
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "2" },
+    "heartfailure_followup_adu_q_1":{"1b":"2","1c":"2","2a":"1","3a":"2","3b":"2"},    
+    "date": {"1a":"1992-5","1b":"","1c":"","2a":"","3a":"","3b":""},
+    "age": { "1a": "22" }
+  }
+
+  InputSingleton.getInstance().setInput(input);
+  expect(heartFailure.clinicalStatus()?.display).toBe("Active");
+  expect(heartFailure.isPresent()).toBe(true);
+  expect(heartFailure.code().display).toBe("Heart failure (disorder)");
+  expect(heartFailure.onsetDateTime()).toBe(undefined);
+  
+});
+
 
 
 test('heart failure, when reported right after baseline (1B)', () => {
@@ -98,6 +140,26 @@ test('heart failure, when reported in 2A, after skipping multiple assessments', 
   expect(heartFailure.onsetDateTime()).toBe("1997-05");
   
 });
+
+
+test('heart failure, when reported in 2A, after skipping multiple assessments', () => {
+
+  const input = {
+    "heartfailure_startage_adu_q_1":{ "1a": "" },
+    "heartfailure_presence_adu_q_1": { "1a": "2" },
+    "heartfailure_followup_adu_q_1":{"1b":undefined,"1c":undefined,"2a":"1","3a":"2","3b":"2"},    
+    "date": {"1a":"1992-5","1b":undefined,"1c":undefined,"2a":"2002-5","3a":"2003-5","3b":"2005-5"},
+    "age": { "1a": "22" }
+  }
+
+  InputSingleton.getInstance().setInput(input);
+  expect(heartFailure.clinicalStatus()?.display).toBe("Active");
+  expect(heartFailure.isPresent()).toBe(true);
+  expect(heartFailure.code().display).toBe("Heart failure (disorder)");
+  expect(heartFailure.onsetDateTime()).toBe("1997-05");
+  
+});
+
 
 
 

--- a/src/viewerserver/serversettings.ts
+++ b/src/viewerserver/serversettings.ts
@@ -10,15 +10,15 @@ export const targets:MappingTarget[] = [
     //{ "template": '../../zib-2017-mappings/HDLCholesterol_Diagnostic_Report.jsonata', "module": './lifelines/HDLCholesterol'},
     //{ "template": '../../zib-2017-mappings/HDLCholesterol_Observation.jsonata', "module": './lifelines/HDLCholesterol'},
     //{ "template": '../../zib-2017-mappings/HDLCholesterol_Specimen.jsonata', "module": './lifelines/HDLCholesterol' },
-    //{ "template": '../../zib-2017-mappings/Patient.jsonata', "module": './lifelines/Patient' },
+    { "template": '../../zib-2017-mappings/Patient.jsonata', "module": './lifelines/Patient' },
     //{ "template": '../../zib-2017-mappings/Stroke.jsonata', "module": './lifelines/Stroke' },
     //{ "template": '../../zib-2017-mappings/TobaccoUse.jsonata', "module": './lifelines/TobaccoUse'} 
-    { "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Diagnostic_Report.jsonata' },
-    { "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Observation.jsonata' },
-    { "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Specimen.jsonata' },
-    { "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Diagnostic_Report.jsonata' },
-    { "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Observation.jsonata' },
-    { "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Specimen.jsonata' },
-
+    //{ "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Diagnostic_Report.jsonata' },
+    //{ "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Observation.jsonata' },
+    //{ "module": './lifelines/eGFR', "template": '../../zib-2017-mappings/generic/LabTestResult_Specimen.jsonata' },
+    //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Diagnostic_Report.jsonata' },
+    //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Observation.jsonata' },
+    //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Specimen.jsonata' },
+    { "template": '../../zib-2017-mappings/generic/Condition.jsonata', "module": './lifelines/HeartFailure' },  
     
   ]


### PR DESCRIPTION
Addressing issue #19 