### PR TITLE
Generating FHIR-Diabetes with undefined onsetdate, instead of assertion failing when the date cannot be calculated

### DIFF
--- a/fhirvalidation/sampleinputs/input-p675432-hf-diab-followup-missing-date.json
+++ b/fhirvalidation/sampleinputs/input-p675432-hf-diab-followup-missing-date.json
@@ -24,13 +24,13 @@
     "stroke_followup_adu_q_1":{"2a":"2","3a":"2","3b":"2"},
 
 
-    "diabetes_presence_adu_q_1":    {"1a":"1"},
-    "diabetes_startage_adu_q_1":    {"1a":"28"},
-    "diabetes_followup_adu_q_1":        {"1b":"2","1c":"2","2a":"2","3a":"2","3b":"2"},
+    "diabetes_presence_adu_q_1":    {"1a":"2"},
+    "diabetes_startage_adu_q_1":    {"1a":""},
+    "diabetes_followup_adu_q_1":        {"1b":"2","1c":"2","2a":"2","3a":"1","3b":"2"},
     "diabetes_type_adu_q_1":        {"1a":"2"},
     "diabetes_type_adu_q_1_a":      {"1a":""},
     "t1d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
-    "t2d_followup_adu_q_1":                 {"2a":"2","3a":"2","3b":"2"},
+    "t2d_followup_adu_q_1":                 {"2a":"2","3a":"1","3b":"2"},
 
     "bp_entrytype_all_m_1":         {"1a":"2","2a":"2"},
     "bp_bandsize_all_m_1":          {"1a":"1","2a":"1","3a":"1"},

--- a/src/__tests__/diabetes.test.ts
+++ b/src/__tests__/diabetes.test.ts
@@ -53,6 +53,38 @@ test('diabetes clinical status, when reported positive in a follow-up, diabetes 
 
 
 
+test('assertion test: diabetes clinical status, when reported positive in a follow-up, but no diabetes type is defined', () => {
+
+  const input = {
+    "diabetes_presence_adu_q_1": { "1a": "2" },
+    "diabetes_followup_adu_q_1": { "1b": "2", "1c": "2", "2a": "2", "3a": "1", "3b": "2" },
+    "diabetes_startage_adu_q_1": { "1a": "" },
+    "diabetes_type_adu_q_1":     { "1a": "2" },
+    "diabetes_type_adu_q_1_a":   { "1a": "" },
+    "t1d_followup_adu_q_1":                            { "2a": "2", "3a": "2", "3b": "2" },
+    "t2d_followup_adu_q_1":                            { "2a": "2", "3a": "2", "3b": "2" },    
+    "date": {"1a":"1992-5","1b":"1995-5","1c":"1997-5",/*date1*/"2a":"2001-5",/*date2*/"3a":"2003-5","3b":"2005-5"},
+    "age": { "1a": "22" },
+  }
+
+  try{
+    InputSingleton.getInstance().setInput(input);
+    expect(diabetesmf.clinicalStatus()).toBe(clinicalStatusSNOMEDCodeList.active);
+    expect(diabetesmf.isPresent()).toBe(true);
+    expect(diabetesmf.code()).toBe(conditionsSNOMEDCodeList.diabetes_mellitus_type_1);
+    expect(diabetesmf.onsetDateTime()).toBe("2002-05");
+    //execution shouldn't reach this point
+    throw new Error('Transformation should have failed with an UnexpectedInputException');
+  }
+  catch(error){
+    if (!(error instanceof UnexpectedInputException)) throw new Error('Transformation should have failed with an UnexpectedInputException');
+  }
+
+});
+
+
+
+
 test('diabetes clinical status, when reported positive in a follow-up after multiple skipped assessments, diabetes type 1', () => {
 
   const input = {
@@ -75,11 +107,11 @@ test('diabetes clinical status, when reported positive in a follow-up after mult
   
 });
 
-test('diabetes clinical status, with inconsistencies, missing date on the assessment where diabetes is reported', () => {
+test('diabetes clinical status (T1D) reported on a follow up, with missing date on the assessment where was reported', () => {
 
   const input = {
     "diabetes_presence_adu_q_1": { "1a": "2" },
-    "diabetes_followup_adu_q_1": { "1b": "2", "1c": "2", "2a": "2", "3a": "", "3b": "1" },
+    "diabetes_followup_adu_q_1": { "1b": "2", "1c": "2", "2a": "2", "3a": "1", "3b": "2" },
     "diabetes_startage_adu_q_1": { "1a": "" },
     "diabetes_type_adu_q_1":     { "1a": "2" },
     "diabetes_type_adu_q_1_a":   { "1a": "" },
@@ -89,16 +121,13 @@ test('diabetes clinical status, with inconsistencies, missing date on the assess
     "age": { "1a": "22" },
   }
 
-  try{
-    InputSingleton.getInstance().setInput(input);
-    expect(diabetesmf.clinicalStatus()).toBe(clinicalStatusSNOMEDCodeList.active);
-    expect(diabetesmf.isPresent()).toBe(true);
-    expect(diabetesmf.code()).toBe(conditionsSNOMEDCodeList.diabetes_mellitus_type_1);
-    expect(diabetesmf.onsetDateTime()).toBe("2003-05");
-  }
-  catch(error){
-    if (!(error instanceof UnexpectedInputException)) fail('Expected exception')
-  }
+  
+  InputSingleton.getInstance().setInput(input);
+  expect(diabetesmf.clinicalStatus()).toBe(clinicalStatusSNOMEDCodeList.active);
+  expect(diabetesmf.isPresent()).toBe(true);
+  expect(diabetesmf.code()).toBe(conditionsSNOMEDCodeList.diabetes_mellitus_type_1);
+  expect(diabetesmf.onsetDateTime()).toBe(undefined);
+  
   
   
 });

--- a/src/lifelines/HeartFailure.ts
+++ b/src/lifelines/HeartFailure.ts
@@ -154,6 +154,7 @@ const _clinicalStatus = moize((heartfailure_presence:string|undefined,followup_a
  * 
  * 
  * @precondition: there is at least one 'yes'/1 on heartfailure_followup_adu_q_1
+ * @precondition there is always a date on one of the assessment prior to the one where diabetes_followup_adu_q_1 was 'yes'
  * 
  * If the date of the assessment where heartfailure_followup_adu_q_1 = yes is available =>
  *      mean date between that particular date (when heartfailure_followup_adu_q_1 = yes), and the date of the preceding assessment.

--- a/src/viewerserver/serversettings.ts
+++ b/src/viewerserver/serversettings.ts
@@ -19,6 +19,6 @@ export const targets:MappingTarget[] = [
     //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Diagnostic_Report.jsonata' },
     //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Observation.jsonata' },
     //{ "module": './lifelines/HaemoglobinConcentration', "template": '../../zib-2017-mappings/generic/LabTestResult_Specimen.jsonata' },
-    { "template": '../../zib-2017-mappings/generic/Condition.jsonata', "module": './lifelines/HeartFailure' },  
+    { "template": '../../zib-2017-mappings/Diabetes.jsonata', "module": './lifelines/Diabetes' },  
     
   ]


### PR DESCRIPTION
Generating FHIR-Diabetes resource with an undefined onsetDate, when Diabetes was reported on a follow-up assessment, and the assessment date is not available. Address issue similar to (closed) #19